### PR TITLE
add test task & solutions

### DIFF
--- a/rust-example-doctests/Cargo.toml
+++ b/rust-example-doctests/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust-example-doctests"
+version = "0.1.0"
+authors = ["Lotte Steenbrink <lotte.steenbrink@ferrous-systems.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust-example-doctests/src/lib.rs
+++ b/rust-example-doctests/src/lib.rs
@@ -1,0 +1,26 @@
+pub struct Square {
+    pub length: f32,
+}
+
+pub trait Shape {
+    fn area(&self) -> f32;
+}
+
+impl Shape for Square {
+    /// Calculates the area of a square.
+    /// usage example:
+    /// ```
+    /// use rust_example_doctests::{Shape, Square};
+    /// let test_square = Square {length: 23.0};
+    /// test_square.area();
+    /// ```
+    fn area(&self) -> f32 {
+        self.length * self.length
+    }
+}
+
+#[test]
+fn test_area() {
+    let test_square = Square {length: 23.0};
+    assert_eq!(529_f32, test_square.area());
+}

--- a/rust-examples/Cargo.toml
+++ b/rust-examples/Cargo.toml
@@ -18,9 +18,17 @@ name = "ownership_borrowing_solution_unidiomatic"
 path = "src/ownership_borrowing_solution_unidiomatic.rs"
 
 [[bin]]
-name = "ownership_borrowing_solution_1"
-path = "src/ownership_borrowing_solution_1.rs"
+name = "ownership_borrowing_solution"
+path = "src/ownership_borrowing_solution.rs"
 
 [[bin]]
 name = "vector_example"
 path = "src/vector_example.rs"
+
+[[bin]]
+name = "tests"
+path = "src/tests.rs"
+
+[[lib]]
+name = "tests_solution"
+path = "src/tests_solution.rs"

--- a/rust-examples/Cargo.toml
+++ b/rust-examples/Cargo.toml
@@ -29,6 +29,6 @@ path = "src/vector_example.rs"
 name = "tests"
 path = "src/tests.rs"
 
-[[lib]]
+[[bin]]
 name = "tests_solution"
 path = "src/tests_solution.rs"

--- a/rust-examples/src/tests.rs
+++ b/rust-examples/src/tests.rs
@@ -1,0 +1,17 @@
+struct Square {
+    length: f32,
+}
+
+trait Shape {
+    fn area(&self) -> f32;
+}
+
+impl Shape for Square {
+    fn area(&self) -> f32 {
+        self.length * self.length
+    }
+}
+
+// TODO: use the #[test] annotation to write a test checking the implementation of `area`.
+// If you'd like to explore more, try grouping several tests in a `#[cfg(test)]` module
+// see: https://doc.rust-lang.org/book/ch11-01-writing-tests.html

--- a/rust-examples/src/tests_solution.rs
+++ b/rust-examples/src/tests_solution.rs
@@ -1,0 +1,21 @@
+struct Square {
+    length: f32,
+}
+
+trait Shape {
+    fn area(&self) -> f32;
+}
+
+impl Shape for Square {
+    // INSTRUCTOR NOTE: for doctest examples, see `../rust-example-doctests`
+    // (doctests only work in libraries and this is a bin target)
+    fn area(&self) -> f32 {
+        self.length * self.length
+    }
+}
+
+#[test]
+fn test_area() {
+    let test_square = Square {length: 23.0};
+    assert_eq!(529_f32, test_square.area());
+}


### PR DESCRIPTION
this could be a quick detour after we've talked about traits because we're writing code in the Traits section that's simple to test :) That's why these examples recycle the code from your slides.

i.e. 

1. Talk about Structs, impls & Traits
2. "now let's see if we can quickly test what we wrote"
3. demo test, have participants write their own test for proof it's that easy
4. maybe quick detour into doctests if we have time/feel like it